### PR TITLE
Fix: no professional template img spacing, and added Name width const…

### DIFF
--- a/src/templates/modern/atoms/ProfileName.tsx
+++ b/src/templates/modern/atoms/ProfileName.tsx
@@ -1,7 +1,7 @@
 export const ProfileName = ({ name }: { name: string }) => {
   return (
     <h3
-      className="text-3xl font-medium max-w-[60%] overflow-hidden overflow-ellipsis whitespace-nowrap"
+      className="text-3xl font-medium max-w-[90%] overflow-hidden overflow-ellipsis whitespace-nowrap"
       title={name}
     >
       {name}

--- a/src/templates/modern/atoms/ProfileName.tsx
+++ b/src/templates/modern/atoms/ProfileName.tsx
@@ -1,3 +1,10 @@
 export const ProfileName = ({ name }: { name: string }) => {
-  return <h3 className="text-3xl font-medium">{name}</h3>;
+  return (
+    <h3
+      className="text-3xl font-medium max-w-[60%] overflow-hidden overflow-ellipsis whitespace-nowrap"
+      title={name}
+    >
+      {name}
+    </h3>
+  );
 };

--- a/src/templates/professional/components/AboutMe.tsx
+++ b/src/templates/professional/components/AboutMe.tsx
@@ -11,12 +11,14 @@ export default function AboutMe({
 }) {
   return (
     <div className="text-[1em]">
-      <ProfileImage
-        src={profileImage}
-        width={'80px'}
-        height={'80px'}
-        imageWrapperClassname={`float-left mr-3 mb-1 ${styles.imageWrapShape}`}
-      />
+      {profileImage.length !== 0 && (
+        <ProfileImage
+          src={profileImage}
+          width={'80px'}
+          height={'80px'}
+          imageWrapperClassname={`float-left mr-3 mb-1 ${styles.imageWrapShape}`}
+        />
+      )}
       <HTMLRenderer htmlString={summary} />
     </div>
   );

--- a/src/templates/professional/components/Section.tsx
+++ b/src/templates/professional/components/Section.tsx
@@ -67,8 +67,14 @@ export function Section({
 }) {
   return (
     <SectionHolder>
-      <div className="header flex justify-center items-center gap-1">
-        <span className={titleClassname ? titleClassname : ''}>{title}</span>
+      <div className="header flex justify-center items-center gap-1 max-w-[60%]" title={title}>
+        <span
+          className={`${
+            titleClassname ? titleClassname : ''
+          } whitespace-nowrap overflow-hidden overflow-ellipsis`}
+        >
+          {title}
+        </span>
       </div>
 
       {profiles && <SocialIcons profiles={profiles} />}


### PR DESCRIPTION
Fixed UI bugs
#### Changes

- Fixed spacing issue of summary on Professional template when no image URL is provided
- Added max width and textOverflow ellipsis to avoid name overflow also added title attribute for better SEO and readability.

Fixes #146 

#### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
