### PR TITLE
Make grid items take same height in the same row

### DIFF
--- a/src/modules/home/components/Feature.tsx
+++ b/src/modules/home/components/Feature.tsx
@@ -45,14 +45,14 @@ function FeatureSection() {
 
 const FeatureCard = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Link href="/builder" passHref={true}>
       <div
         className={`transition ease-in-out delay-100 duration-300 bg-resume-100 hover:bg-resume-500 text-resume-800
-      hover:text-resume-50 fill-resume-800 px-6 py-10 lg:p-12 flex shadow-md cursor-pointer relative rounded-xl`}
+      hover:text-resume-50 fill-resume-800 px-6 py-10 lg:p-12 flex shadow-md cursor-pointer relative rounded-xl h-full`}
       >
+        <Link href="/builder" passHref={true}>
         {children}
+        </Link>
       </div>
-    </Link>
   );
 };
 


### PR DESCRIPTION
#### Changes


Fixes # (issue)
Inconsistent item height on production
![image](https://github.com/sadanandpai/resume-builder/assets/26523871/8bb8b75c-7d8a-4a24-a3af-09d29a0e4cd9)

