### PR TITLE
Fix: Education section date spacing

### DIFF
--- a/src/modules/home/components/Feature.tsx
+++ b/src/modules/home/components/Feature.tsx
@@ -45,14 +45,14 @@ function FeatureSection() {
 
 const FeatureCard = ({ children }: { children: React.ReactNode }) => {
   return (
-      <div
-        className={`transition ease-in-out delay-100 duration-300 bg-resume-100 hover:bg-resume-500 text-resume-800
+    <div
+      className={`transition ease-in-out delay-100 duration-300 bg-resume-100 hover:bg-resume-500 text-resume-800
       hover:text-resume-50 fill-resume-800 px-6 py-10 lg:p-12 flex shadow-md cursor-pointer relative rounded-xl h-full`}
-      >
-        <Link href="/builder" passHref={true}>
+    >
+      <Link href="/builder" passHref={true}>
         {children}
-        </Link>
-      </div>
+      </Link>
+    </div>
   );
 };
 

--- a/src/templates/modern/components/Education.tsx
+++ b/src/templates/modern/components/Education.tsx
@@ -18,10 +18,10 @@ export const EducationSection = ({ education }: { education: IEducation[] }) => 
                 <SectionSubtitle label={item.institution} />
                 <div className="flex gap-3">
                   <p className="text-xs">
-                    {dateParser(item.startDate)} -
-                    {item.isStudyingHere ? 'present' : dateParser(item.endDate)}
+                    {`${dateParser(item.startDate)} - ${
+                      item.isStudyingHere ? 'present' : dateParser(item.endDate)
+                    }`}
                   </p>
-                  {/* <p className="text-xs">60%</p> */}
                 </div>
               </div>
             </div>

--- a/src/templates/professional/components/Education.tsx
+++ b/src/templates/professional/components/Education.tsx
@@ -15,8 +15,9 @@ export const Education = ({ education }: { education: IEducation[] }) => {
                 <p className="font-normal">{item.institution}</p>
                 <div className="flex gap-3">
                   <p className="text-xs">
-                    {dateParser(item.startDate)} -
-                    {item.isStudyingHere ? 'present' : dateParser(item.endDate)}
+                    {`${dateParser(item.startDate)} - ${
+                      item.isStudyingHere ? 'present' : dateParser(item.endDate)
+                    }`}
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
#### Changes

This PR fixes date spacing issue in Education section.

| Before | After |
|--------|--------|
| <img width="309" alt="image" src="https://github.com/user-attachments/assets/b72322cf-49c8-4d9e-b1bb-e28d1ce85ecc"> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/460e11e0-941e-4697-b2ca-1e9af103f6a0"> | 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
